### PR TITLE
Handle 'player'

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function onMessage(message) {
   if (msg.startsWith('You were tipped')) {
     const arr = getHoverData(message);
     try {
-      const tips = /by (\d*) players/.exec(msg)[1];
+      const tips = /by (\d*) players?/.exec(msg)[1];
       tipIncrement(uuid, { type: 'received', amount: tips }, arr);
     } catch (e) {
       //


### PR DESCRIPTION
Hypixel returns `You were tipped by 1 player in the last minute!` when only one player has tipped instead of `players`
This should fix the issue where is the script crashes when its regex finds nothing.